### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML injection in EmailSender

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-09 - HTML Injection in EmailSender
+**Vulnerability:** The `EmailSender` utility in `kipp/utils/mailsender.py` was vulnerable to HTML injection because `parse_content` and `generate_table` methods were constructing HTML by direct string interpolation of user-provided content without escaping.
+**Learning:** Utilities that convert text to HTML are common vectors for injection if developers assume the input is safe. Even if the output is an email, mail clients can be vulnerable to XSS or phishing if the HTML is not properly sanitized.
+**Prevention:** Always escape user-controlled text before inserting it into HTML templates. Use standard library functions like `html.escape` for this purpose.

--- a/kipp/utils/mailsender.py
+++ b/kipp/utils/mailsender.py
@@ -28,6 +28,10 @@ import smtplib
 from textwrap import dedent
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 
 from .logger import get_logger as get_kipp_logger
 
@@ -84,8 +88,10 @@ class EmailSender(object):
     #     self._mail_from = settings.FROM_ADDRESS
 
     def parse_content(self, content):
+        # Escape user-provided content to prevent HTML injection
+        escaped_content = escape(content)
         return '<font face="Microsoft YaHei, Helvetica Neue, Helvetica">{}</font>'.format(
-            "<p>{}</p>".format("</p><p>".join(content.splitlines()))
+            "<p>{}</p>".format("</p><p>".join(escaped_content.splitlines()))
         )
 
     def get_html(self, body):
@@ -178,11 +184,11 @@ class EmailSender(object):
 
             table_html = sender.generate_table(heads, contents)
         """
-        thead = "".join(["<th><p>{}</p></th>\n".format(str(h)) for h in heads])
+        thead = "".join(["<th><p>{}</p></th>\n".format(escape(str(h))) for h in heads])
         tbody = ""
         for cnt in contents:
             tbody += "<tr>{}</tr>\n".format(
-                "".join(["<td><p>{}</p></td>".format(str(h)) for h in cnt])
+                "".join(["<td><p>{}</p></td>".format(escape(str(h))) for h in cnt])
             )
 
         return dedent(

--- a/tests/test_security_mailsender.py
+++ b/tests/test_security_mailsender.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+from unittest import TestCase
+from kipp.utils import EmailSender
+
+class SecurityEmailSenderTestCase(TestCase):
+    def setUp(self):
+        self.sender = EmailSender("fake_host")
+
+    def test_parse_content_injection(self):
+        malicious_content = "Safe content</p><script>alert('XSS')</script><p>"
+        result = self.sender.parse_content(malicious_content)
+        # Check that the script tag is NOT present in its raw form
+        self.assertNotIn("<script>alert('XSS')</script>", result)
+        # Check that it IS present in its escaped form
+        self.assertIn("&lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;", result.replace("'", "&#x27;"))
+
+    def test_generate_table_injection(self):
+        heads = ("head1", "head2<script>alert('XSS')</script>")
+        contents = [("cell1", "cell2<img src=x onerror=alert(1)>")]
+        result = self.sender.generate_table(heads, contents)
+        self.assertNotIn("<script>alert('XSS')</script>", result)
+        self.assertNotIn("<img src=x onerror=alert(1)>", result)
+        self.assertIn("&lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;", result.replace("'", "&#x27;"))
+        self.assertIn("&lt;img src=x onerror=alert(1)&gt;", result)
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix HTML injection in EmailSender

### 🚨 Severity: HIGH
### 💡 Vulnerability: HTML Injection
The \`EmailSender\` utility class in \`kipp/utils/mailsender.py\` was constructing HTML strings for email content and tables by directly interpolating user-provided strings without any escaping or sanitization.

### 🎯 Impact:
An attacker who can control the content passed to \`EmailSender.send_email\` or \`EmailSender.generate_table\` could inject arbitrary HTML tags and scripts. This could lead to Cross-Site Scripting (XSS) in web-based mail clients or be used for phishing and layout manipulation.

### 🔧 Fix:
- Added imports for \`html.escape\` (with \`cgi.escape\` fallback for Python 2).
- Applied \`escape()\` to all user-provided strings in \`parse_content\` and \`generate_table\` before they are placed inside HTML tags.

### ✅ Verification:
- Created \`tests/test_security_mailsender.py\` with test cases for both \`parse_content\` and \`generate_table\` using malicious payloads.
- Verified that the malicious payloads are correctly escaped in the output.
- Verified that the existing \`tests/test_send_email.py\` still passes with the changes.

---
*PR created automatically by Jules for task [806757587488311197](https://jules.google.com/task/806757587488311197) started by @Laisky*